### PR TITLE
modules/API.md Add more detail to docs for RM_AutoMemory

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -657,10 +657,16 @@ long long RM_Milliseconds(void) {
  * Automatic memory management for modules
  * -------------------------------------------------------------------------- */
 
-/* Enable automatic memory management. See API.md for more information.
+/* Enable automatic memory management. When using automatic memory management,
+ * you do not need to explicitly free `RedisModuleCallReply`,
+ * `RedisModuleString`, and `RedisModuleKey` objects created in the current
+ * `RedisModuleCtx`. These objects will be released automatically when the
+ * callback returns.
  *
  * The function must be called as the first function of a command implementation
- * that wants to use automatic memory. */
+ * that wants to use automatic memory. 
+ * 
+ * For automatically managing memory for other types, see `RedisModulePoolAlloc`.*/
 void RM_AutoMemory(RedisModuleCtx *ctx) {
     ctx->flags |= REDISMODULE_CTX_AUTO_MEMORY;
 }

--- a/src/modules/API.md
+++ b/src/modules/API.md
@@ -169,10 +169,16 @@ Return the current UNIX time in milliseconds.
 
     void RM_AutoMemory(RedisModuleCtx *ctx);
 
-Enable automatic memory management. See API.md for more information.
+Enable automatic memory management. When using automatic memory management,
+ you do not need to explicitly free `RedisModuleCallReply`,
+ `RedisModuleString`, and `RedisModuleKey` objects created in the current
+ `RedisModuleCtx`. These objects will be released automatically when the
+  callback returns.
 
-The function must be called as the first function of a command implementation
-that wants to use automatic memory.
+ The function must be called as the first function of a command implementation
+ that wants to use automatic memory. 
+ 
+ For automatically managing memory for other types, see `RedisModulePoolAlloc`.
 
 ## `RM_CreateString`
 


### PR DESCRIPTION
As far as I can tell, RM_AutoMemory is only for RM objects
(RM keys, RM strings, and RM replies), and not for any type
of object. I added this information to the comments for
RM_AutoMemory and to modules/API.md.